### PR TITLE
Delete and vacuum databricks table

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,40 @@ This is a test repository for cursor development and testing purposes.
 ## Features
 - Basic repository setup
 - README documentation
+- Databricks table operations (delete and vacuum)
 - Ready for development
+
+## Databricks Table Operations
+
+This repository contains Python Spark code to manage Databricks tables, specifically implementing delete and vacuum operations for the table `client_catalog.temp.dummy_table`.
+
+### Files
+- `databricks_table_operations.py`: Main Python script with Spark code for table operations
+- `requirements.txt`: Python dependencies required to run the script
+
+### Usage
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the script:
+```bash
+python databricks_table_operations.py
+```
+
+The script will:
+- Connect to your Databricks cluster using PySpark
+- Delete the specified table (`client_catalog.temp.dummy_table`)
+- Vacuum the table to clean up old files
+- Provide comprehensive logging of all operations
+
+### Requirements
+- Python 3.7+
+- PySpark 3.4.0+
+- Access to Databricks cluster
+- Appropriate permissions to delete and vacuum tables in the `client_catalog.temp` schema
 
 ## Getting Started
 Clone this repository and start developing!

--- a/databricks_table_operations.py
+++ b/databricks_table_operations.py
@@ -1,0 +1,187 @@
+"""
+Databricks Table Operations - Delete and Vacuum
+
+This script provides functionality to delete and vacuum a Databricks table
+using PySpark. Specifically designed to work with the table:
+client_catalog.temp.dummy_table
+
+Author: Generated for Linear Issue COM-5
+Date: 2025
+"""
+
+from pyspark.sql import SparkSession
+import logging
+import sys
+from typing import Optional
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class DatabricksTableManager:
+    """
+    A class to manage Databricks table operations including delete and vacuum.
+    """
+    
+    def __init__(self, app_name: str = "DatabricksTableOperations"):
+        """
+        Initialize the Spark session for Databricks operations.
+        
+        Args:
+            app_name: Name of the Spark application
+        """
+        try:
+            self.spark = SparkSession.builder \
+                .appName(app_name) \
+                .getOrCreate()
+            logger.info("Spark session initialized successfully")
+        except Exception as e:
+            logger.error(f"Failed to initialize Spark session: {str(e)}")
+            raise
+    
+    def delete_table(self, table_name: str) -> bool:
+        """
+        Delete a Databricks table.
+        
+        Args:
+            table_name: Full table name (catalog.schema.table)
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        try:
+            logger.info(f"Attempting to delete table: {table_name}")
+            
+            # Check if table exists
+            if not self._table_exists(table_name):
+                logger.warning(f"Table {table_name} does not exist")
+                return True
+            
+            # Delete the table
+            self.spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+            logger.info(f"Successfully deleted table: {table_name}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to delete table {table_name}: {str(e)}")
+            return False
+    
+    def vacuum_table(self, table_name: str, retention_hours: int = 168) -> bool:
+        """
+        Vacuum a Databricks table to remove old files.
+        
+        Args:
+            table_name: Full table name (catalog.schema.table)
+            retention_hours: Number of hours to retain files (default 168 hours = 7 days)
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        try:
+            logger.info(f"Attempting to vacuum table: {table_name}")
+            
+            # Check if table exists
+            if not self._table_exists(table_name):
+                logger.warning(f"Table {table_name} does not exist, skipping vacuum")
+                return True
+            
+            # Vacuum the table
+            vacuum_sql = f"VACUUM {table_name} RETAIN {retention_hours} HOURS"
+            self.spark.sql(vacuum_sql)
+            logger.info(f"Successfully vacuumed table: {table_name}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to vacuum table {table_name}: {str(e)}")
+            return False
+    
+    def delete_and_vacuum_table(self, table_name: str, retention_hours: int = 168) -> bool:
+        """
+        Delete and then vacuum a Databricks table.
+        
+        Args:
+            table_name: Full table name (catalog.schema.table)
+            retention_hours: Number of hours to retain files during vacuum
+            
+        Returns:
+            bool: True if both operations successful, False otherwise
+        """
+        logger.info(f"Starting delete and vacuum operation for table: {table_name}")
+        
+        # First vacuum to clean up old files before deletion
+        vacuum_success = self.vacuum_table(table_name, retention_hours)
+        
+        # Then delete the table
+        delete_success = self.delete_table(table_name)
+        
+        if delete_success and vacuum_success:
+            logger.info(f"Successfully completed delete and vacuum for table: {table_name}")
+            return True
+        else:
+            logger.error(f"Failed to complete delete and vacuum for table: {table_name}")
+            return False
+    
+    def _table_exists(self, table_name: str) -> bool:
+        """
+        Check if a table exists in Databricks.
+        
+        Args:
+            table_name: Full table name (catalog.schema.table)
+            
+        Returns:
+            bool: True if table exists, False otherwise
+        """
+        try:
+            result = self.spark.sql(f"SHOW TABLES IN {table_name.rsplit('.', 1)[0]} LIKE '{table_name.split('.')[-1]}'")
+            return result.count() > 0
+        except Exception as e:
+            logger.warning(f"Could not check if table exists: {str(e)}")
+            return False
+    
+    def close(self):
+        """Close the Spark session."""
+        if self.spark:
+            self.spark.stop()
+            logger.info("Spark session closed")
+
+
+def main():
+    """
+    Main function to execute the delete and vacuum operation for the specified table.
+    """
+    # Target table as specified in the Linear issue
+    TARGET_TABLE = "client_catalog.temp.dummy_table"
+    
+    # Initialize table manager
+    table_manager = None
+    
+    try:
+        # Create table manager
+        table_manager = DatabricksTableManager()
+        
+        # Execute delete and vacuum operation
+        success = table_manager.delete_and_vacuum_table(TARGET_TABLE)
+        
+        if success:
+            logger.info("Operation completed successfully!")
+            sys.exit(0)
+        else:
+            logger.error("Operation failed!")
+            sys.exit(1)
+            
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        sys.exit(1)
+        
+    finally:
+        # Clean up resources
+        if table_manager:
+            table_manager.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# Python Spark Dependencies for Databricks Operations
+# Required for Linear Issue COM-5
+
+# PySpark - Main dependency for Spark operations
+pyspark>=3.4.0
+
+# Optional: Additional dependencies for enhanced functionality
+# databricks-connect>=13.0.0  # Uncomment if using Databricks Connect
+# delta-spark>=2.4.0          # Uncomment if working with Delta Lake tables
+
+# Development dependencies (uncomment if needed for testing)
+# pytest>=7.0.0
+# pytest-spark>=0.6.0


### PR DESCRIPTION
Add Python Spark code to delete and vacuum the `client_catalog.temp.dummy_table` in Databricks, resolving Linear issue COM-5.

---
Linear Issue: [COM-5](https://linear.app/commerceiq/issue/COM-5/testing-linear-poc)

<a href="https://cursor.com/background-agent?bcId=bc-17c40d68-3eab-4dfe-8254-c594c4a6dce6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17c40d68-3eab-4dfe-8254-c594c4a6dce6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

